### PR TITLE
test(node_napi): Add a Regression Test

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -27,6 +27,23 @@ findstr "366667" out.txt || goto :test_fail_print
 type out.txt
 echo Successfull!!
 
+echo Node NAPI Tests
+set "LOADER_SCRIPT_PATH=%loc%\node_napi"
+
+rem TODO: NAPI native addon support - napi_* symbols not re-exported by MetaCall's node.dll
+rem TODO: https://github.com/metacall/distributable-windows/issues/
+echo Npm Install rspack Test
+call metacall npm install --prefix="%loc%\node_napi" @rspack/core
+if %errorlevel%==1 goto :test_fail
+echo Successfull!!
+
+echo Node NAPI rspack Test
+type "%loc%\node_napi\commands.txt" | metacall ^> out.txt
+if %errorlevel%==1 goto :test_fail
+findstr "rspack" out.txt || goto :test_fail_print
+type out.txt
+echo Successfull!!
+
 echo Python Tests
 set "LOADER_SCRIPT_PATH=%loc%\python"
 

--- a/test.bat
+++ b/test.bat
@@ -30,10 +30,8 @@ echo Successfull!!
 echo Node NAPI Tests
 set "LOADER_SCRIPT_PATH=%loc%\node_napi"
 
-rem TODO: NAPI native addon support - napi_* symbols not re-exported by MetaCall's node.dll
-rem TODO: https://github.com/metacall/distributable-windows/issues/
 echo Npm Install rspack Test
-call metacall npm install --prefix="%loc%\node_napi" @rspack/core
+call metacall npm install --prefix="%loc%\node_napi" @rspack/core@1.7.9
 if %errorlevel%==1 goto :test_fail
 echo Successfull!!
 

--- a/tests/node_napi/commands.txt
+++ b/tests/node_napi/commands.txt
@@ -1,0 +1,3 @@
+load node index.js
+call check()
+exit

--- a/tests/node_napi/index.js
+++ b/tests/node_napi/index.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/*
+ *	MetaCall Distributable by Parra Studios
+ *	Distributable infrastructure for MetaCall.
+ *
+ *	Copyright (C) 2016 - 2025 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ *
+ */
+
+// Regression test for MetaCall NAPI native addon support.
+// @rspack/core depends on @rspack/binding, a Rust-compiled NAPI addon (napi-rs).
+// MetaCall's embedded node.dll must re-export all napi_* symbols for this to work.
+// This test fails until MetaCall ships proper NAPI symbol re-export support.
+// Tracking issue: https://github.com/metacall/distributable-windows/issues/
+
+const { rspackVersion } = require('@rspack/core');
+
+module.exports = {
+	check: function() {
+		console.log('rspack loaded, version: ' + rspackVersion);
+	},
+};

--- a/tests/node_napi/index.js
+++ b/tests/node_napi/index.js
@@ -22,10 +22,7 @@
 
 // Regression test for MetaCall NAPI native addon support.
 // @rspack/core depends on @rspack/binding, a Rust-compiled NAPI addon (napi-rs).
-// MetaCall's embedded node.dll must re-export all napi_* symbols for this to work.
-// This test fails until MetaCall ships proper NAPI symbol re-export support.
-// Tracking issue: https://github.com/metacall/distributable-windows/issues/
-
+// https://github.com/metacall/core/pull/696
 const { rspackVersion } = require('@rspack/core');
 
 module.exports = {


### PR DESCRIPTION
Adds tests for Node.js NAPI module support using rspack. This includes a new batch file for running the tests and JavaScript and command files for the Node.js NAPI test case. This test is expected to fail until MetaCall's node.dll properly re-exports napi_* symbols"hypo".